### PR TITLE
Update  dependiencies to use built in quicksilver-script installer type

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,24 +6,6 @@ This Quicksilver project is used for automation of deployment tracking with New 
 
 This project is designed to be included from a site's `composer.json` file, and placed in its appropriate installation directory by [Composer Installers](https://github.com/composer/installers). 
 
-It has to also include custom quick-silver installer as composer installer doesn't support the quicksilver-script type.
-
-In order for this to work, you should have the following in your composer.json file:
-
-```json
-{
-  "require": {
-    "composer/installers": "^1.0.20",
-    "rvtraveller/qs-composer-installer": "1.0"
-  },
-  "extra": {
-    "installer-paths": {
-      "web/private/scripts/quicksilver/{$name}/": ["type:quicksilver-script"]
-    }
-  }
-}
-```
-
 The project can be included by using the command:
 
 `composer require kalamuna/quicksilver-newrelic-tracking`

--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,7 @@
   "description": "Quicksilver project is used for automation of deployment tracking with New Relic on Pantheon platform.",
   "type": "quicksilver-script",
   "require": {
-    "composer/installers": "~1.0",
-    "rvtraveller/qs-composer-installer": "~1.0"
+    "composer/installers": "^2.0.1"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
Confirmed a composer require without adding anything to composer.json in advance installs it in the right place

![CleanShot 2024-06-26 at 15 05 53@2x](https://github.com/kalamuna/quicksilver-newrelic-tracking/assets/53239/ca231b52-6777-4804-b8b6-d428c5c40497)
